### PR TITLE
Changed CLI to use argparse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ docs/build
 docs/fj.db
 docs/src
 *.db
+.vagrant
+Vagrantfile

--- a/freejournal_cli.py
+++ b/freejournal_cli.py
@@ -1,6 +1,5 @@
 #!/usr/bin/python
 from frontend.cli import commands
-import sys
 
 if __name__ == '__main__':
-    commands.process_command(sys.argv)
+    commands.process_command()

--- a/frontend/cli/commands.py
+++ b/frontend/cli/commands.py
@@ -1,317 +1,110 @@
 #!/usr/bin/python
 
-import sys, datetime, uuid
+import sys, datetime, uuid, argparse, platform
 
-# BitMessage installer imports
-import platform
-from bitmessage.install import apt_install, windows_install
-
-# FreeNet installer imports
-from freenet.install import linux_install
-
-try:
-    from controllers import collections
-except:
-    print('SQLAlchemy import error')
-
-# FreeJournal library imports
+from helpers import get_doc_file, put_document, list_collections, list_collection_version, list_collection_details, show_collection, install_dependencies, put_collection, publish_collection
 import config
-try:
-    from cache.cache import Cache
-    cache = Cache()
-except:
-    print ("Warning: SQLite is not installed.  No local cache " \
-        + "functionality available.")
 
-try:
-    from models.collection import Collection
-    from models.keyword import Keyword
-    from models.document import Document
-except:
-    print ("Error: could not import models.")
+# Base parser
+parser = argparse.ArgumentParser(description="FreeJournal Client")
+subparsers = parser.add_subparsers(help="FreeJournal client commands", dest="command")
 
-try:
-    from bitmessage.bitmessage import Bitmessage
-    from backend.controller import Controller
-except:
-    print ("Error: could not import BitMessage dependencies.")
+# Subcommand parsers
+# getdoc
+parser_getdoc = subparsers.add_parser("getdoc",
+                                      help="get a document with given hash from the FreeJournal network storage")
+parser_getdoc.add_argument("hash", type=str, help="hash of the document to get")
+parser_getdoc.add_argument("output_path", type=str, help="path to save the document to")
 
-# Frontend imports
-try:
-    from frontend.webapp import app as webapp
-except:
-    print ("Error: could not import webapp.")
+# putdoc
+parser_putdoc = subparsers.add_parser("putdoc",
+                                      help="add a document to the FreeJournal network storage and create the local"
+                                           + " corresponding document object, displaying the document ID required "
+                                           + " to retrieve the document with the configured key.  To publish, "
+                                           + " use the `pubcollection` command with the returned document ID.")
+parser_putdoc.add_argument("path", type=str, help="path of the document to upload")
+parser_putdoc.add_argument("address", type=str, help="BitMessage address of the collection to add this document to")
+parser_putdoc.add_argument("title", type=str, help="title of the document")
+parser_putdoc.add_argument("description", type=str, help="description of the document")
 
-try:
-    # Freenet may not be installed
-    import freenet
-    from freenet.FreenetConnection import FreenetConnection
-    freenet_installed = True
-except:
-    freenet_installed = False
+# listcollections
+parser_listcollections = subparsers.add_parser("listcollections",
+                                               help="list all document indexes currently known to this FreeJournal"
+                                                    + "instance")
 
-def print_help():
-    """ Print usage instructions for the command-line library. """
-    print ("Usage: ./freejournal [command]")
-    print ("./freejournal_cli help [command name] - display extended command information.\n")
-    print ("Available commands:")
-    print ("\tgetdoc [document hash] [document output path/filename]")
-    print ("\tputdoc [document input path] [collection address] [title] [description]")
-    print ("\tlistcollections")
-    print ("\tlistversions [collection address] [(optional) 'documents' to print document_ids]")
-    print ("\tlisten")
-    print ("\tinstall [freenet|bitmessage|all]")
-    print ("\tshowcollection [index bitmessage ID]")
-    print ("\tputcollection [address password] [title] [description] [keywords] " \
-            + "[Bitcoin address (for rating)]")
-    print ("\tpublishcollection [address password] [index bitmessage ID]")
-    print ("\twebapp")
-    print ("\tuploader")
-    print ("\tkeepalive")
+parser_listversions = subparsers.add_parser("listversions", help="list all the versions of a particular collection")
+parser_listversions.add_argument("address", help="BitMessage address of the collection")
+parser_listversions.add_argument("-d", "--documents", action="store_true", dest="show_documents",
+                                 help="print document_ids")
 
-def print_command_help(command):
-    """ Display extended help information for CLI command
-        :param command: FreeJournal command name"""
-    COMMANDS = \
-        { "getdoc": \
-            "Get a document with given hash from the FreeJournal network storage.", \
-          "putdoc": \
-            "Add a document to the FreeJournal network storage and create the local" \
-            + " corresponding document object, displaying the document ID required " \
-            + " to retreive the document with the configured key.  To publish, " \
-            + " call pubcollection with the returned document ID.", \
-          "listcollections": \
-            "List all document indexes currently known to this FreeJournal instance.", \
-          "listversions": \
-            "List all the versions of a particular collection", \
-          "showcollection": \
-            "Display all known details of a given collection, including all documents it indexes.", \
-          "listen": \
-            "Start the long-running FreeJournal listener.", \
-          "install": \
-            "Perform initial setup, installing FreeJournal dependencies.", \
-          "putcollection": \
-            "Create a new collection and store it locally.", \
-          "publishcollection": \
-            "Publish a local collection to the world (other FreeJournal nodes).", \
-          "webapp": \
-            "Run the FreeJournal web application (webapp).", \
-          "uploader": \
-            "Run the FreeJournal graphical desktop application/uploader.", \
-          "keepalive": \
-            "Run network keepalive functionality (republish indexes to the BitMessage network)." \
-        }
-    if command in COMMANDS:
-        print (COMMANDS[command])
-    else:
-        print ("Unknown command!")
-        print_help()
+# listen
+parser_listen = subparsers.add_parser("listen", help="start the long-running FreeJournal listener")
 
-def get_doc_file(document_hash, document_output_filename):
-    """ Get a document file from the Freenet network
-        :param document_hash: the Freenet URI to retreive
-        :param document_output_filename: path/filename to write to
-    """
-    freeCon = FreenetConnection()
-    output=freeCon.get(document_hash)
-    open(document_output_filename, 'w').write(output)
-    print ("File with URL " + document_hash + " written to " + document_output_filename)
+parser_install = subparsers.add_parser("install", help="install FreeJournal dependencies")
+parser_install.add_argument("deps", choices=["freenet", "bitmessage", "all"], help="dependencies to install")
 
-def list_collections():
-    """ List all collections in the local cache """
-    print ("Available collections, cached locally: ")
-    for collection in cache.get_all_collections():
-        print ("\n\tID " + collection.address + "\t " + collection.title + \
-            "\tCreation Date " + collection.creation_date.strftime("%A, %d. %B %Y %I:%M%p"))
-        print ("\t" +"~~~~~~~~~~~~~~~Document list~~~~~~~~~~~~~~~")
-        print ("\t\t" + "URI" + "\t" + "Title" + "\t" + "Description")
-        documents = cache.get_documents_from_collection(collection.address)
-        for doc in documents:
-            print ("\t\t" + doc.hash + "\t" + doc.title +  "\t" + doc.description)
+# showcollection
+parser_showcollection = subparsers.add_parser("showcollection", help="display all known details of a given collection,"
+                                                                     + "including all documents it indexes")
+parser_showcollection.add_argument("address", help="BitMessage address of the collection")
 
-def list_collection_details(collection_address):
-    collection = cache.get_collection_with_address(collection_address)
-    if collection is not None:
-        print (collection.to_json())
-    else:
-        print ("Collection not found in local cache.")
+# putcollection
+parser_putcollection = subparsers.add_parser("putcollection", help="create a new collection and store it locally")
+parser_putcollection.add_argument("address_password", help="the password with which to protect the collection")
+parser_putcollection.add_argument("title", help="title for the new collection")
+parser_putcollection.add_argument("description", help="description for the new collection")
+parser_putcollection.add_argument("keywords", help="comma-separated keywords")
+parser_putcollection.add_argument("btc_address", help="Bitcoin address for donations")
+
+# publishcollection
+parser_publishcollection = subparsers.add_parser("publishcollection", help="publish a local collection to the world"
+                                                                           + "(other FreeJournal nodes)")
+parser_publishcollection.add_argument("address_password", help="the password for this collection")
+parser_publishcollection.add_argument("id", help="the BitMessage ID for this collection")
+
+# webapp
+parser_webapp = subparsers.add_parser("webapp", help="run the HTTP server front end")
+
+# uploader
+parser_uploader = subparsers.add_parser("uploader", help="run the uploader GUI application")
+
+# keepalive
+parser_keepalive = subparsers.add_parser("keepalive", help="run the keep-alive function to help sustain the FreeJournal"
+                                                           + "network")
 
 
-def list_collection_version(collection_address, document_ids):
-    versions = cache.get_versions_for_collection(collection_address)
-    if(len(versions)!=0):
-        print("Collection Versions for " + collection_address + ":" )
-        print ("\t" + "Root hash" + "\t\t\t\t\t\t\t\t" + "Collection Version")
-    else:
-        print("Collection not found")
-    for version in versions:
-        print("\t" + version.root_hash + "\t" + str(version.collection_version))
-        if(document_ids == 'documents'):
-            print("document_ids:")
-            print(version.document_ids)
-            print("")
-
-def install_dependencies(dependency):
-    """ Install a prerequisite (dependency) for deploying a FreeJournal
-        node.  Rerun with each FreeJournal upgrade.
-        :param dependency: Software to install, freenet/bitmessage/all
-    """
-    dependency = dependency.lower()
-    if dependency == 'freenet' or dependency == 'all':
-        os = sys.platform
-        if 'linux' not in os:
-            raise Exception("Invalid Operating System. See README.")
-        else:
-            linux_install()
-    if dependency == 'bitmessage' or dependency == 'all':
-        os_version = platform.dist()[0]
-        if 'windows' in os_version:
-            windows_install()
-        else:
-            apt_install()
-            print ('Installation Completed')
-
-def put_document(file_path, collection_address, title, description):
-    """ Insert a document into the local cache with associated information
-        and upload the document to the freenet network.
-        :param file_path: the path of the file to upload
-        :param collection_address: the collection address associated with the document
-        :param title: the title of the document being uploaded
-        :param description: the description of the document being uploaded
-    """
-    file_name = file_path.rsplit('/',1)[0]
-    contents = open(file_path).read()
-    freeCon = FreenetConnection()
-    uri = freeCon.put(contents)
-    document = Document(
-        collection_address = collection_address,
-        description = description,
-        hash = uri,
-        title = title,
-        filename = file_name,
-        accesses = 0
-    )
-    cache.insert_new_document(document)
-    collection = cache.get_collection_with_address(collection_address)
-    collections.update_hash(collection)
-    print ("Inserted " + file_path + " successfully with URI " + uri)
-    print ("Allow up to 10 minutes for file to propogate on the freenet network")
-
-def put_collection(address_password, title, description, keywords, btc):
-    """ Create a collection in local cache
-        :param address_password: The password with which to protect the collection.
-        Should be at least 20 characters for optimal security and unique.  Generates 
-        the unique collection ID deterministically
-        :param title: The title of the created collection
-        :param description: The description of the created collection
-        :param keywords: Comma-separated keywords for the resulting collection
-        :param BTC: the Bitcoin address of the resulting collection
-    """
-    bitmessage_connection = Bitmessage()
-    address = bitmessage_connection.create_address(address_password)
-    keywords = [Keyword(name=x) for x in keywords.split(",")]
-    collection = Collection(
-        title=title,
-        description=description,
-        address=address,
-        accesses=0,
-        votes=0,
-        btc=btc,
-        keywords=keywords,
-        documents=[],
-        creation_date=datetime.datetime.now(),
-        oldest_date=datetime.datetime.now(),
-        votes_last_checked=datetime.datetime.now(),
-        latest_broadcast_date=datetime.datetime.now()
-    )
-    cache.insert_new_collection(collection)
-    print ("Collection inserted with address/ID " + address)
-
-
-def show_collection(collection_address):
-    '''
-    Displays information about a specific collection, including a document list
-    :param collection_address: Collection address
-    '''
-    collection = cache.get_collection_with_address(collection_address)
-    print ("\tID " + collection.address + "\t " + collection.title + \
-            "\tCreation Date " + collection.creation_date.strftime("%A, %d. %B %Y %I:%M%p"))
-    print ("\t" +"~~~~~~~~~~~~~~~"+ "Document list"+"~~~~~~~~~~~~~~~")
-    print ("\t\t" + "URI" + "\t" + "Title" + "\t" + "Description")
-    documents = cache.get_documents_from_collection(collection_address)
-    for doc in documents:
-        print ("\t\t" + doc.hash + "\t" + doc.title +  "\t" + doc.description)
-
-def publish_collection(address_password, collection_address):
-    bitmessage_connection = Bitmessage()
-    address = bitmessage_connection.create_address(address_password)
-    collection = cache.get_collection_with_address(collection_address)
-    if collection is not None:
-        collection_handler = Controller()
-        collection_handler.publish_collection(collection, config.MAIN_CHANNEL_ADDRESS, address)
-        print ("Collection published successfully!")
-    else:
-        print ("Collection not found in local cache.")
-
-
-def validate_cli_arguments(length):
-    if (len(sys.argv) == length):
-        return True
-    print_help()
-
-def process_command(command):
-    """ Process a command-line command and execute the 
+def process_command():
+    """ Process a commafrend-line command and execute the
         resulting FreeJournal action
         :param command: The command to be executed, as a sys arg array
     """
-    if len(sys.argv) < 2:
-        print_help()
-        return
-    command = sys.argv[1].lower()
-    if command == 'help':
-        if (validate_cli_arguments(3)):
-            print_command_help(sys.argv[2])
-    elif command == 'getdoc':
-        if (validate_cli_arguments(3)):
-            get_doc_file(sys.argv[2], sys.argv[3])
+    args = parser.parse_args()
+    command = args.command
+    if command == 'getdoc':
+        get_doc_file(args.hash, args.output_path)
     elif command == 'putdoc':
-        if (validate_cli_arguments(6)):
-            put_document(sys.argv[2],sys.argv[3],sys.argv[4],sys.argv[5])
+        put_document(args.path, args.address, args.title, args.description)
     elif command == 'listcollections':
         list_collections()
     elif command == 'listversions':
-        if (len(sys.argv) ==3):
-            list_collection_version(sys.argv[2],None)
-        elif (len(sys.argv)==4 and sys.argv[3]=='documents'):
-            list_collection_version(sys.argv[2],sys.argv[3])    
-        else:
-            print_help()
+        list_collection_version(args.address, args.show_documents)
     elif command == 'showcollection':
-        if (validate_cli_arguments(3)):
-            show_collection(sys.argv[2])
+        show_collection(args.address)
     elif command == 'listen':
         from bitmessage.bitmessage_listener import get_collections
         get_collections()
     elif command == 'install':
-        if (validate_cli_arguments(3)):
-            install_dependencies(sys.argv[2])
+        install_dependencies(args.deps)
     elif command == 'putcollection':
-        if (validate_cli_arguments(7)):
-            put_collection(sys.argv[2], \
-                sys.argv[3], sys.argv[4], \
-                sys.argv[5], sys.argv[6])
+        put_collection(args.address_password, args.title, args.description, args.keywords, args.btc_address)
     elif command == 'publishcollection':
-        if (validate_cli_arguments(4)):
-            publish_collection(sys.argv[2], sys.argv[3])
-        else:
-            print_help()
+        publish_collection(args.address_password, args.id)
     elif command == 'webapp':
-        webapp.run(debug = config.WEBAPP_DEBUG, port = config.WEBAPP_PORT)
+        import frontend.webapp.app as webapp
+        webapp.run(debug=config.WEBAPP_DEBUG, port=config.WEBAPP_PORT)
     elif command == 'uploader':
         from frontend.uploader import fjUploaderGUI
         fjUploaderGUI.run()
     elif command == 'keepalive':
         from bitmessage.bitmessage_keepalive import find_old_collections
         find_old_collections(3)
-    else:
-        print_help()

--- a/frontend/cli/helpers.py
+++ b/frontend/cli/helpers.py
@@ -1,0 +1,196 @@
+import sys
+import datetime
+import platform
+
+# BitMessage installer imports
+from bitmessage.install import apt_install, windows_install
+
+# FreeNet installer imports
+from freenet.install import linux_install
+
+try:
+    from controllers import collections
+except:
+    print('SQLAlchemy import error')
+
+# FreeJournal library imports
+import config
+try:
+    from cache.cache import Cache
+    cache = Cache()
+except:
+    print ("Warning: SQLite is not installed.  No local cache " \
+           + "functionality available.")
+
+try:
+    from models.collection import Collection
+    from models.keyword import Keyword
+    from models.document import Document
+except:
+    print ("Error: could not import models.")
+
+try:
+    from bitmessage.bitmessage import Bitmessage
+    from controllers.controller import Controller
+except:
+    print ("Error: could not import BitMessage dependencies.")
+
+
+try:
+    # Freenet may not be installed
+    import freenet
+    from freenet.FreenetConnection import FreenetConnection
+    freenet_installed = True
+except:
+    freenet_installed = False
+
+
+def get_doc_file(document_hash, document_output_filename):
+    """ Get a document file from the Freenet network
+        :param document_hash: the Freenet URI to retreive
+        :param document_output_filename: path/filename to write to
+    """
+    free_conn = FreenetConnection()
+    output = free_conn.get(document_hash)
+    open(document_output_filename, 'w').write(output)
+    print ("File with URL " + document_hash + " written to " + document_output_filename)
+
+
+def list_collections():
+    """ List all collections in the local cache """
+    print ("Available collections, cached locally: ")
+    for collection in cache.get_all_collections():
+        print ("\n\tID " + collection.address + "\t " + collection.title + \
+               "\tCreation Date " + collection.creation_date.strftime("%A, %d. %B %Y %I:%M%p"))
+        print ("\t" +"~~~~~~~~~~~~~~~Document list~~~~~~~~~~~~~~~")
+        print ("\t\t" + "URI" + "\t" + "Title" + "\t" + "Description")
+        documents = cache.get_documents_from_collection(collection.address)
+        for doc in documents:
+            print ("\t\t" + doc.hash + "\t" + doc.title +  "\t" + doc.description)
+
+
+def list_collection_details(collection_address):
+    collection = cache.get_collection_with_address(collection_address)
+    if collection is not None:
+        print (collection.to_json())
+    else:
+        print ("Collection not found in local cache.")
+
+
+def list_collection_version(collection_address, show_document_ids):
+    versions = cache.get_versions_for_collection(collection_address)
+    if(len(versions)!=0):
+        print("Collection Versions for " + collection_address + ":" )
+        print ("\t" + "Root hash" + "\t\t\t\t\t\t\t\t" + "Collection Version")
+    else:
+        print("Collection not found")
+    for version in versions:
+        print("\t" + version.root_hash + "\t" + str(version.collection_version))
+        if show_document_ids:
+            print("document_ids:")
+            print(version.document_ids)
+            print("")
+
+
+def install_dependencies(dependency):
+    """ Install a prerequisite (dependency) for deploying a FreeJournal
+        node.  Rerun with each FreeJournal upgrade.
+        :param dependency: Software to install, freenet/bitmessage/all
+    """
+    if dependency == 'freenet' or dependency == 'all':
+        os = sys.platform
+        if 'linux' not in os:
+            raise Exception("Invalid Operating System. See README.")
+        else:
+            linux_install()
+    if dependency == 'bitmessage' or dependency == 'all':
+        os_version = platform.dist()[0]
+        if 'windows' in os_version:
+            windows_install()
+        else:
+            apt_install()
+            print ('Installation Completed')
+
+
+def put_document(file_path, collection_address, title, description):
+    """ Insert a document into the local cache with associated information
+        and upload the document to the freenet network.
+        :param file_path: the path of the file to upload
+        :param collection_address: the collection address associated with the document
+        :param title: the title of the document being uploaded
+        :param description: the description of the document being uploaded
+    """
+    file_name = file_path.rsplit('/',1)[0]
+    contents = open(file_path).read()
+    free_conn = FreenetConnection()
+    uri = free_conn.put(contents)
+    document = Document(
+        collection_address=collection_address,
+        description=description,
+        hash=uri,
+        title=title,
+        filename=file_name,
+        accesses=0
+    )
+    cache.insert_new_document(document)
+    collection = cache.get_collection_with_address(collection_address)
+    collections.update_hash(collection)
+    print ("Inserted " + file_path + " successfully with URI " + uri)
+    print ("Allow up to 10 minutes for file to propogate on the freenet network")
+
+def put_collection(address_password, title, description, keywords, btc):
+    """ Create a collection in local cache
+        :param address_password: The password with which to protect the collection.
+        Should be at least 20 characters for optimal security and unique.  Generates 
+        the unique collection ID deterministically
+        :param title: The title of the created collection
+        :param description: The description of the created collection
+        :param keywords: Comma-separated keywords for the resulting collection
+        :param BTC: the Bitcoin address of the resulting collection
+    """
+    bitmessage_connection = Bitmessage()
+    address = bitmessage_connection.create_address(address_password)
+    keywords = [Keyword(name=x) for x in keywords.split(",")]
+    collection = Collection(
+        title=title,
+        description=description,
+        address=address,
+        accesses=0,
+        votes=0,
+        btc=btc,
+        keywords=keywords,
+        documents=[],
+        creation_date=datetime.datetime.now(),
+        oldest_date=datetime.datetime.now(),
+        votes_last_checked=datetime.datetime.now(),
+        latest_broadcast_date=datetime.datetime.now()
+    )
+    cache.insert_new_collection(collection)
+    print ("Collection inserted with address/ID " + address)
+
+
+def show_collection(collection_address):
+    '''
+    Displays information about a specific collection, including a document list
+    :param collection_address: Collection address
+    '''
+    collection = cache.get_collection_with_address(collection_address)
+    print ("\tID " + collection.address + "\t " + collection.title + \
+           "\tCreation Date " + collection.creation_date.strftime("%A, %d. %B %Y %I:%M%p"))
+    print ("\t" +"~~~~~~~~~~~~~~~"+ "Document list"+"~~~~~~~~~~~~~~~")
+    print ("\t\t" + "URI" + "\t" + "Title" + "\t" + "Description")
+    documents = cache.get_documents_from_collection(collection_address)
+    for doc in documents:
+        print ("\t\t" + doc.hash + "\t" + doc.title +  "\t" + doc.description)
+
+
+def publish_collection(address_password, collection_address):
+    bitmessage_connection = Bitmessage()
+    address = bitmessage_connection.create_address(address_password)
+    collection = cache.get_collection_with_address(collection_address)
+    if collection is not None:
+        collection_handler = Controller()
+        collection_handler.publish_collection(collection, config.MAIN_CHANNEL_ADDRESS, address)
+        print ("Collection published successfully!")
+    else:
+        print ("Collection not found in local cache.")


### PR DESCRIPTION
The "commands" file was pretty messy, so I put together an `argparse` parser for command line arguments. It'll handle improper number of arguments/optional arguments/help text for us. There is only one breaking change I noticed which is that `listversions` now takes a `-d` or `--documents` flag for showing document versions, so instead of `./freejournal_cli.py listversions documents`, it's `./freejournal_cli.py listversions -d` or `./freejournal_cli.py listversions --documents`.
