### PR TITLE
Celerybeat task for listener

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ docs/src
 *.db
 .vagrant
 Vagrantfile
+celerybeat-schedule
+celerybeat.pid

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ docs/build
 docs/fj.db
 docs/src
 *.db
+.vagrant
+Vagrantfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
 
 before_install:
   - sudo apt-get update
-  - sudo apt-get install -qq python openssl git python-qt4
+  - sudo apt-get install -qq python openssl git python-qt4 rabbitmq-server
 
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,9 @@ before_install:
 
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install:
-  - pip install --upgrade pip
-  - pip install -r requirements.txt
-  - pip install coveralls
+  - sudo pip install --upgrade pip
+  - sudo pip install -r requirements.txt
+  - sudo pip install coveralls
   - ./freejournal_cli.py install bitmessage
 
 # command to run tests, e.g. python setup.py test

--- a/celery_target.py
+++ b/celery_target.py
@@ -1,0 +1,1 @@
+from tasks import *

--- a/freejournal_cli.py
+++ b/freejournal_cli.py
@@ -1,6 +1,5 @@
 #!/usr/bin/python
 from frontend.cli import commands
-import sys
 
 if __name__ == '__main__':
-    commands.process_command(sys.argv)
+    commands.process_command()

--- a/frontend/cli/commands.py
+++ b/frontend/cli/commands.py
@@ -41,7 +41,8 @@ parser_listversions.add_argument("-d", "--documents", action="store_true", dest=
 parser_listen = subparsers.add_parser("listen", help="start the long-running FreeJournal listener")
 
 parser_install = subparsers.add_parser("install", help="install FreeJournal dependencies")
-parser_install.add_argument("deps", choices=["freenet", "bitmessage", "all"], help="dependencies to install")
+parser_install.add_argument("deps", choices=["freenet", "bitmessage", "rabbitmq", "all"],
+                            help="dependencies to install")
 
 # showcollection
 parser_showcollection = subparsers.add_parser("showcollection", help="display all known details of a given collection,"

--- a/frontend/cli/commands.py
+++ b/frontend/cli/commands.py
@@ -1,317 +1,110 @@
 #!/usr/bin/python
 
-import sys, datetime, uuid
+import sys, datetime, uuid, argparse, platform
 
-# BitMessage installer imports
-import platform
-from bitmessage.install import apt_install, windows_install
-
-# FreeNet installer imports
-from freenet.install import linux_install
-
-try:
-    from controllers import collections
-except:
-    print('SQLAlchemy import error')
-
-# FreeJournal library imports
+from helpers import get_doc_file, put_document, list_collections, list_collection_version, list_collection_details, show_collection, install_dependencies, put_collection, publish_collection
 import config
-try:
-    from cache.cache import Cache
-    cache = Cache()
-except:
-    print ("Warning: SQLite is not installed.  No local cache " \
-        + "functionality available.")
 
-try:
-    from models.collection import Collection
-    from models.keyword import Keyword
-    from models.document import Document
-except:
-    print ("Error: could not import models.")
+# Base parser
+parser = argparse.ArgumentParser(description="FreeJournal Client")
+subparsers = parser.add_subparsers(help="FreeJournal client commands", dest="command")
 
-try:
-    from bitmessage.bitmessage import Bitmessage
-    from backend.controller import Controller
-except:
-    print ("Error: could not import BitMessage dependencies.")
+# Subcommand parsers
+# getdoc
+parser_getdoc = subparsers.add_parser("getdoc",
+                                      help="get a document with given hash from the FreeJournal network storage")
+parser_getdoc.add_argument("hash", type=str, help="hash of the document to get")
+parser_getdoc.add_argument("output_path", type=str, help="path to save the document to")
 
-# Frontend imports
-try:
-    from frontend.webapp import app as webapp
-except:
-    print ("Error: could not import webapp.")
+# putdoc
+parser_putdoc = subparsers.add_parser("putdoc",
+                                      help="add a document to the FreeJournal network storage and create the local"
+                                           + " corresponding document object, displaying the document ID required "
+                                           + " to retrieve the document with the configured key.  To publish, "
+                                           + " use the `pubcollection` command with the returned document ID.")
+parser_putdoc.add_argument("path", type=str, help="path of the document to upload")
+parser_putdoc.add_argument("address", type=str, help="BitMessage address of the collection to add this document to")
+parser_putdoc.add_argument("title", type=str, help="title of the document")
+parser_putdoc.add_argument("description", type=str, help="description of the document")
 
-try:
-    # Freenet may not be installed
-    import freenet
-    from freenet.FreenetConnection import FreenetConnection
-    freenet_installed = True
-except:
-    freenet_installed = False
+# listcollections
+parser_listcollections = subparsers.add_parser("listcollections",
+                                               help="list all document indexes currently known to this FreeJournal"
+                                                    + "instance")
 
-def print_help():
-    """ Print usage instructions for the command-line library. """
-    print ("Usage: ./freejournal [command]")
-    print ("./freejournal_cli help [command name] - display extended command information.\n")
-    print ("Available commands:")
-    print ("\tgetdoc [document hash] [document output path/filename]")
-    print ("\tputdoc [document input path] [collection address] [title] [description]")
-    print ("\tlistcollections")
-    print ("\tlistversions [collection address] [(optional) 'documents' to print document_ids]")
-    print ("\tlisten")
-    print ("\tinstall [freenet|bitmessage|all]")
-    print ("\tshowcollection [index bitmessage ID]")
-    print ("\tputcollection [address password] [title] [description] [keywords] " \
-            + "[Bitcoin address (for rating)]")
-    print ("\tpublishcollection [address password] [index bitmessage ID]")
-    print ("\twebapp")
-    print ("\tuploader")
-    print ("\tkeepalive")
+parser_listversions = subparsers.add_parser("listversions", help="list all the versions of a particular collection")
+parser_listversions.add_argument("address", help="BitMessage address of the collection")
+parser_listversions.add_argument("-d", "--documents", action="store_true", dest="show_documents",
+                                 help="print document_ids")
 
-def print_command_help(command):
-    """ Display extended help information for CLI command
-        :param command: FreeJournal command name"""
-    COMMANDS = \
-        { "getdoc": \
-            "Get a document with given hash from the FreeJournal network storage.", \
-          "putdoc": \
-            "Add a document to the FreeJournal network storage and create the local" \
-            + " corresponding document object, displaying the document ID required " \
-            + " to retreive the document with the configured key.  To publish, " \
-            + " call pubcollection with the returned document ID.", \
-          "listcollections": \
-            "List all document indexes currently known to this FreeJournal instance.", \
-          "listversions": \
-            "List all the versions of a particular collection", \
-          "showcollection": \
-            "Display all known details of a given collection, including all documents it indexes.", \
-          "listen": \
-            "Start the long-running FreeJournal listener.", \
-          "install": \
-            "Perform initial setup, installing FreeJournal dependencies.", \
-          "putcollection": \
-            "Create a new collection and store it locally.", \
-          "publishcollection": \
-            "Publish a local collection to the world (other FreeJournal nodes).", \
-          "webapp": \
-            "Run the FreeJournal web application (webapp).", \
-          "uploader": \
-            "Run the FreeJournal graphical desktop application/uploader.", \
-          "keepalive": \
-            "Run network keepalive functionality (republish indexes to the BitMessage network)." \
-        }
-    if command in COMMANDS:
-        print (COMMANDS[command])
-    else:
-        print ("Unknown command!")
-        print_help()
+# listen
+parser_listen = subparsers.add_parser("listen", help="start the long-running FreeJournal listener")
 
-def get_doc_file(document_hash, document_output_filename):
-    """ Get a document file from the Freenet network
-        :param document_hash: the Freenet URI to retreive
-        :param document_output_filename: path/filename to write to
-    """
-    freeCon = FreenetConnection()
-    output=freeCon.get(document_hash)
-    open(document_output_filename, 'w').write(output)
-    print ("File with URL " + document_hash + " written to " + document_output_filename)
+parser_install = subparsers.add_parser("install", help="install FreeJournal dependencies")
+parser_install.add_argument("deps", choices=["freenet", "bitmessage", "all"], help="dependencies to install")
 
-def list_collections():
-    """ List all collections in the local cache """
-    print ("Available collections, cached locally: ")
-    for collection in cache.get_all_collections():
-        print ("\n\tID " + collection.address + "\t " + collection.title + \
-            "\tCreation Date " + collection.creation_date.strftime("%A, %d. %B %Y %I:%M%p"))
-        print ("\t" +"~~~~~~~~~~~~~~~Document list~~~~~~~~~~~~~~~")
-        print ("\t\t" + "URI" + "\t" + "Title" + "\t" + "Description")
-        documents = cache.get_documents_from_collection(collection.address)
-        for doc in documents:
-            print ("\t\t" + doc.hash + "\t" + doc.title +  "\t" + doc.description)
+# showcollection
+parser_showcollection = subparsers.add_parser("showcollection", help="display all known details of a given collection,"
+                                                                     + "including all documents it indexes")
+parser_showcollection.add_argument("address", help="BitMessage address of the collection")
 
-def list_collection_details(collection_address):
-    collection = cache.get_collection_with_address(collection_address)
-    if collection is not None:
-        print (collection.to_json())
-    else:
-        print ("Collection not found in local cache.")
+# putcollection
+parser_putcollection = subparsers.add_parser("putcollection", help="create a new collection and store it locally")
+parser_putcollection.add_argument("address_password", help="the password with which to protect the collection")
+parser_putcollection.add_argument("title", help="title for the new collection")
+parser_putcollection.add_argument("description", help="description for the new collection")
+parser_putcollection.add_argument("keywords", help="comma-separated keywords")
+parser_putcollection.add_argument("btc_address", help="Bitcoin address for donations")
+
+# publishcollection
+parser_publishcollection = subparsers.add_parser("publishcollection", help="publish a local collection to the world"
+                                                                           + "(other FreeJournal nodes)")
+parser_publishcollection.add_argument("address_password", help="the password for this collection")
+parser_publishcollection.add_argument("id", help="the BitMessage ID for this collection")
+
+# webapp
+parser_webapp = subparsers.add_parser("webapp", help="run the HTTP server front end")
+
+# uploader
+parser_uploader = subparsers.add_parser("uploader", help="run the uploader GUI application")
+
+# keepalive
+parser_keepalive = subparsers.add_parser("keepalive", help="run the keep-alive function to help sustain the FreeJournal"
+                                                           + "network")
 
 
-def list_collection_version(collection_address, document_ids):
-    versions = cache.get_versions_for_collection(collection_address)
-    if(len(versions)!=0):
-        print("Collection Versions for " + collection_address + ":" )
-        print ("\t" + "Root hash" + "\t\t\t\t\t\t\t\t" + "Collection Version")
-    else:
-        print("Collection not found")
-    for version in versions:
-        print("\t" + version.root_hash + "\t" + str(version.collection_version))
-        if(document_ids == 'documents'):
-            print("document_ids:")
-            print(version.document_ids)
-            print("")
-
-def install_dependencies(dependency):
-    """ Install a prerequisite (dependency) for deploying a FreeJournal
-        node.  Rerun with each FreeJournal upgrade.
-        :param dependency: Software to install, freenet/bitmessage/all
-    """
-    dependency = dependency.lower()
-    if dependency == 'freenet' or dependency == 'all':
-        os = sys.platform
-        if 'linux' not in os:
-            raise Exception("Invalid Operating System. See README.")
-        else:
-            linux_install()
-    if dependency == 'bitmessage' or dependency == 'all':
-        os_version = platform.dist()[0]
-        if 'windows' in os_version:
-            windows_install()
-        else:
-            apt_install()
-            print ('Installation Completed')
-
-def put_document(file_path, collection_address, title, description):
-    """ Insert a document into the local cache with associated information
-        and upload the document to the freenet network.
-        :param file_path: the path of the file to upload
-        :param collection_address: the collection address associated with the document
-        :param title: the title of the document being uploaded
-        :param description: the description of the document being uploaded
-    """
-    file_name = file_path.rsplit('/',1)[0]
-    contents = open(file_path).read()
-    freeCon = FreenetConnection()
-    uri = freeCon.put(contents)
-    document = Document(
-        collection_address = collection_address,
-        description = description,
-        hash = uri,
-        title = title,
-        filename = file_name,
-        accesses = 0
-    )
-    cache.insert_new_document(document)
-    collection = cache.get_collection_with_address(collection_address)
-    collections.update_hash(collection)
-    print ("Inserted " + file_path + " successfully with URI " + uri)
-    print ("Allow up to 10 minutes for file to propogate on the freenet network")
-
-def put_collection(address_password, title, description, keywords, btc):
-    """ Create a collection in local cache
-        :param address_password: The password with which to protect the collection.
-        Should be at least 20 characters for optimal security and unique.  Generates 
-        the unique collection ID deterministically
-        :param title: The title of the created collection
-        :param description: The description of the created collection
-        :param keywords: Comma-separated keywords for the resulting collection
-        :param BTC: the Bitcoin address of the resulting collection
-    """
-    bitmessage_connection = Bitmessage()
-    address = bitmessage_connection.create_address(address_password)
-    keywords = [Keyword(name=x) for x in keywords.split(",")]
-    collection = Collection(
-        title=title,
-        description=description,
-        address=address,
-        accesses=0,
-        votes=0,
-        btc=btc,
-        keywords=keywords,
-        documents=[],
-        creation_date=datetime.datetime.now(),
-        oldest_date=datetime.datetime.now(),
-        votes_last_checked=datetime.datetime.now(),
-        latest_broadcast_date=datetime.datetime.now()
-    )
-    cache.insert_new_collection(collection)
-    print ("Collection inserted with address/ID " + address)
-
-
-def show_collection(collection_address):
-    '''
-    Displays information about a specific collection, including a document list
-    :param collection_address: Collection address
-    '''
-    collection = cache.get_collection_with_address(collection_address)
-    print ("\tID " + collection.address + "\t " + collection.title + \
-            "\tCreation Date " + collection.creation_date.strftime("%A, %d. %B %Y %I:%M%p"))
-    print ("\t" +"~~~~~~~~~~~~~~~"+ "Document list"+"~~~~~~~~~~~~~~~")
-    print ("\t\t" + "URI" + "\t" + "Title" + "\t" + "Description")
-    documents = cache.get_documents_from_collection(collection_address)
-    for doc in documents:
-        print ("\t\t" + doc.hash + "\t" + doc.title +  "\t" + doc.description)
-
-def publish_collection(address_password, collection_address):
-    bitmessage_connection = Bitmessage()
-    address = bitmessage_connection.create_address(address_password)
-    collection = cache.get_collection_with_address(collection_address)
-    if collection is not None:
-        collection_handler = Controller()
-        collection_handler.publish_collection(collection, config.MAIN_CHANNEL_ADDRESS, address)
-        print ("Collection published successfully!")
-    else:
-        print ("Collection not found in local cache.")
-
-
-def validate_cli_arguments(length):
-    if (len(sys.argv) == length):
-        return True
-    print_help()
-
-def process_command(command):
-    """ Process a command-line command and execute the 
+def process_command():
+    """ Process a commafrend-line command and execute the
         resulting FreeJournal action
         :param command: The command to be executed, as a sys arg array
     """
-    if len(sys.argv) < 2:
-        print_help()
-        return
-    command = sys.argv[1].lower()
-    if command == 'help':
-        if (validate_cli_arguments(3)):
-            print_command_help(sys.argv[2])
-    elif command == 'getdoc':
-        if (validate_cli_arguments(3)):
-            get_doc_file(sys.argv[2], sys.argv[3])
+    args = parser.parse_args()
+    command = args.command
+    if command == 'getdoc':
+        get_doc_file(args.hash, args.output_path)
     elif command == 'putdoc':
-        if (validate_cli_arguments(6)):
-            put_document(sys.argv[2],sys.argv[3],sys.argv[4],sys.argv[5])
+        put_document(args.path, args.address, args.title, args.description)
     elif command == 'listcollections':
         list_collections()
     elif command == 'listversions':
-        if (len(sys.argv) ==3):
-            list_collection_version(sys.argv[2],None)
-        elif (len(sys.argv)==4 and sys.argv[3]=='documents'):
-            list_collection_version(sys.argv[2],sys.argv[3])    
-        else:
-            print_help()
+        list_collection_version(args.address, args.show_documents)
     elif command == 'showcollection':
-        if (validate_cli_arguments(3)):
-            show_collection(sys.argv[2])
+        show_collection(args.address)
     elif command == 'listen':
         from bitmessage.bitmessage_listener import get_collections
         get_collections()
     elif command == 'install':
-        if (validate_cli_arguments(3)):
-            install_dependencies(sys.argv[2])
+        install_dependencies(args.deps)
     elif command == 'putcollection':
-        if (validate_cli_arguments(7)):
-            put_collection(sys.argv[2], \
-                sys.argv[3], sys.argv[4], \
-                sys.argv[5], sys.argv[6])
+        put_collection(args.address_password, args.title, args.description, args.keywords, args.btc_address)
     elif command == 'publishcollection':
-        if (validate_cli_arguments(4)):
-            publish_collection(sys.argv[2], sys.argv[3])
-        else:
-            print_help()
+        publish_collection(args.address_password, args.id)
     elif command == 'webapp':
-        webapp.run(debug = config.WEBAPP_DEBUG, port = config.WEBAPP_PORT)
+        import frontend.webapp.app as webapp
+        webapp.run(debug=config.WEBAPP_DEBUG, port=config.WEBAPP_PORT)
     elif command == 'uploader':
         from frontend.uploader import fjUploaderGUI
         fjUploaderGUI.run()
     elif command == 'keepalive':
         from bitmessage.bitmessage_keepalive import find_old_collections
         find_old_collections(3)
-    else:
-        print_help()

--- a/frontend/cli/helpers.py
+++ b/frontend/cli/helpers.py
@@ -8,6 +8,8 @@ from bitmessage.install import apt_install, windows_install
 # FreeNet installer imports
 from freenet.install import linux_install
 
+from tasks.install import rabbitmq_install
+
 try:
     from controllers import collections
 except:
@@ -103,6 +105,12 @@ def install_dependencies(dependency):
             raise Exception("Invalid Operating System. See README.")
         else:
             linux_install()
+    if dependency == 'rabbitmq' or dependency == 'all':
+        os = sys.platform
+        if 'linux' not in os:
+            raise Exception("Invalid Operating System. See README.")
+        else:
+            rabbitmq_install()
     if dependency == 'bitmessage' or dependency == 'all':
         os_version = platform.dist()[0]
         if 'windows' in os_version:

--- a/frontend/cli/helpers.py
+++ b/frontend/cli/helpers.py
@@ -1,0 +1,196 @@
+import sys
+import datetime
+import platform
+
+# BitMessage installer imports
+from bitmessage.install import apt_install, windows_install
+
+# FreeNet installer imports
+from freenet.install import linux_install
+
+try:
+    from controllers import collections
+except:
+    print('SQLAlchemy import error')
+
+# FreeJournal library imports
+import config
+try:
+    from cache.cache import Cache
+    cache = Cache()
+except:
+    print ("Warning: SQLite is not installed.  No local cache " \
+           + "functionality available.")
+
+try:
+    from models.collection import Collection
+    from models.keyword import Keyword
+    from models.document import Document
+except:
+    print ("Error: could not import models.")
+
+try:
+    from bitmessage.bitmessage import Bitmessage
+    from controllers.controller import Controller
+except:
+    print ("Error: could not import BitMessage dependencies.")
+
+
+try:
+    # Freenet may not be installed
+    import freenet
+    from freenet.FreenetConnection import FreenetConnection
+    freenet_installed = True
+except:
+    freenet_installed = False
+
+
+def get_doc_file(document_hash, document_output_filename):
+    """ Get a document file from the Freenet network
+        :param document_hash: the Freenet URI to retreive
+        :param document_output_filename: path/filename to write to
+    """
+    free_conn = FreenetConnection()
+    output = free_conn.get(document_hash)
+    open(document_output_filename, 'w').write(output)
+    print ("File with URL " + document_hash + " written to " + document_output_filename)
+
+
+def list_collections():
+    """ List all collections in the local cache """
+    print ("Available collections, cached locally: ")
+    for collection in cache.get_all_collections():
+        print ("\n\tID " + collection.address + "\t " + collection.title + \
+               "\tCreation Date " + collection.creation_date.strftime("%A, %d. %B %Y %I:%M%p"))
+        print ("\t" +"~~~~~~~~~~~~~~~Document list~~~~~~~~~~~~~~~")
+        print ("\t\t" + "URI" + "\t" + "Title" + "\t" + "Description")
+        documents = cache.get_documents_from_collection(collection.address)
+        for doc in documents:
+            print ("\t\t" + doc.hash + "\t" + doc.title +  "\t" + doc.description)
+
+
+def list_collection_details(collection_address):
+    collection = cache.get_collection_with_address(collection_address)
+    if collection is not None:
+        print (collection.to_json())
+    else:
+        print ("Collection not found in local cache.")
+
+
+def list_collection_version(collection_address, show_document_ids):
+    versions = cache.get_versions_for_collection(collection_address)
+    if(len(versions)!=0):
+        print("Collection Versions for " + collection_address + ":" )
+        print ("\t" + "Root hash" + "\t\t\t\t\t\t\t\t" + "Collection Version")
+    else:
+        print("Collection not found")
+    for version in versions:
+        print("\t" + version.root_hash + "\t" + str(version.collection_version))
+        if show_document_ids:
+            print("document_ids:")
+            print(version.document_ids)
+            print("")
+
+
+def install_dependencies(dependency):
+    """ Install a prerequisite (dependency) for deploying a FreeJournal
+        node.  Rerun with each FreeJournal upgrade.
+        :param dependency: Software to install, freenet/bitmessage/all
+    """
+    if dependency == 'freenet' or dependency == 'all':
+        os = sys.platform
+        if 'linux' not in os:
+            raise Exception("Invalid Operating System. See README.")
+        else:
+            linux_install()
+    if dependency == 'bitmessage' or dependency == 'all':
+        os_version = platform.dist()[0]
+        if 'windows' in os_version:
+            windows_install()
+        else:
+            apt_install()
+            print ('Installation Completed')
+
+
+def put_document(file_path, collection_address, title, description):
+    """ Insert a document into the local cache with associated information
+        and upload the document to the freenet network.
+        :param file_path: the path of the file to upload
+        :param collection_address: the collection address associated with the document
+        :param title: the title of the document being uploaded
+        :param description: the description of the document being uploaded
+    """
+    file_name = file_path.rsplit('/',1)[0]
+    contents = open(file_path).read()
+    free_conn = FreenetConnection()
+    uri = free_conn.put(contents)
+    document = Document(
+        collection_address=collection_address,
+        description=description,
+        hash=uri,
+        title=title,
+        filename=file_name,
+        accesses=0
+    )
+    cache.insert_new_document(document)
+    collection = cache.get_collection_with_address(collection_address)
+    collections.update_hash(collection)
+    print ("Inserted " + file_path + " successfully with URI " + uri)
+    print ("Allow up to 10 minutes for file to propogate on the freenet network")
+
+def put_collection(address_password, title, description, keywords, btc):
+    """ Create a collection in local cache
+        :param address_password: The password with which to protect the collection.
+        Should be at least 20 characters for optimal security and unique.  Generates 
+        the unique collection ID deterministically
+        :param title: The title of the created collection
+        :param description: The description of the created collection
+        :param keywords: Comma-separated keywords for the resulting collection
+        :param BTC: the Bitcoin address of the resulting collection
+    """
+    bitmessage_connection = Bitmessage()
+    address = bitmessage_connection.create_address(address_password)
+    keywords = [Keyword(name=x) for x in keywords.split(",")]
+    collection = Collection(
+        title=title,
+        description=description,
+        address=address,
+        accesses=0,
+        votes=0,
+        btc=btc,
+        keywords=keywords,
+        documents=[],
+        creation_date=datetime.datetime.now(),
+        oldest_date=datetime.datetime.now(),
+        votes_last_checked=datetime.datetime.now(),
+        latest_broadcast_date=datetime.datetime.now()
+    )
+    cache.insert_new_collection(collection)
+    print ("Collection inserted with address/ID " + address)
+
+
+def show_collection(collection_address):
+    '''
+    Displays information about a specific collection, including a document list
+    :param collection_address: Collection address
+    '''
+    collection = cache.get_collection_with_address(collection_address)
+    print ("\tID " + collection.address + "\t " + collection.title + \
+           "\tCreation Date " + collection.creation_date.strftime("%A, %d. %B %Y %I:%M%p"))
+    print ("\t" +"~~~~~~~~~~~~~~~"+ "Document list"+"~~~~~~~~~~~~~~~")
+    print ("\t\t" + "URI" + "\t" + "Title" + "\t" + "Description")
+    documents = cache.get_documents_from_collection(collection_address)
+    for doc in documents:
+        print ("\t\t" + doc.hash + "\t" + doc.title +  "\t" + doc.description)
+
+
+def publish_collection(address_password, collection_address):
+    bitmessage_connection = Bitmessage()
+    address = bitmessage_connection.create_address(address_password)
+    collection = cache.get_collection_with_address(collection_address)
+    if collection is not None:
+        collection_handler = Controller()
+        collection_handler.publish_collection(collection, config.MAIN_CHANNEL_ADDRESS, address)
+        print ("Collection published successfully!")
+    else:
+        print ("Collection not found in local cache.")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 sqlalchemy==0.9.8
-celery==3.1.17
+celery==3.1.19
 epydoc==3.0.1
 requests==2.5.3
 pyfcp==0.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 sqlalchemy==0.9.8
-celery==3.1.19
+celery==3.1.18
 epydoc==3.0.1
 requests==2.5.3
 pyfcp==0.2.0

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -1,0 +1,19 @@
+from celery import Celery
+
+from controllers.controller import Controller
+from config import MAIN_CHANNEL_ADDRESS
+
+
+celery_app = Celery('tasks')
+celery_app.config_from_object('tasks.celery_config')
+
+@celery_app.task
+def get_collections():
+    """Get collections from the main channel"""
+    collection_handler = Controller()
+    collection_handler.import_collection(MAIN_CHANNEL_ADDRESS)
+
+@celery_app.task
+def test():
+    pass
+

--- a/tasks/add_task.py
+++ b/tasks/add_task.py
@@ -1,6 +1,0 @@
-from frontend.webapp import celery
-
-@celery.task()
-def add_together(a, b):
-    print "running add task!"
-    return a + b

--- a/tasks/celery_config.py
+++ b/tasks/celery_config.py
@@ -1,0 +1,16 @@
+from datetime import timedelta
+
+BROKER_URL = 'amqp://'
+
+CELERYBEAT_SCHEDULE = {
+    'listen': {
+        'task': 'tasks.get_collections',
+        'schedule': timedelta(seconds=30),
+    },
+    'test': {
+        'task': 'tasks.test',
+        'schedule': timedelta(seconds=10),
+    }
+}
+
+CELERY_TIMEZONE = 'UTC'

--- a/tasks/install.py
+++ b/tasks/install.py
@@ -1,0 +1,9 @@
+import subprocess
+
+
+def rabbitmq_install():
+    """
+    Generic installation for linux versions using apt
+    """
+    subprocess.call(["sudo apt-get update"], shell=True)
+    subprocess.call(["sudo apt-get install rabbitmq -y"], shell=True)

--- a/tasks/periodic_test.py
+++ b/tasks/periodic_test.py
@@ -1,6 +1,0 @@
-from frontend.webapp import celery
-
-@celery.task(name="periodic_test")
-def add_test(a, b):
-    print "I added things!", str(a + b)
-    return a + b

--- a/tasks/tasks.py
+++ b/tasks/tasks.py
@@ -1,0 +1,11 @@
+from controllers.controller import Controller
+from config import MAIN_CHANNEL_ADDRESS
+
+
+def get_collections():
+    """Get collections from the main channel"""
+
+    collection_handler = Controller()
+    new_collection = True
+    while new_collection:
+        collection_handler.import_collection(MAIN_CHANNEL_ADDRESS)


### PR DESCRIPTION
Put together a Celerybeat task for the listener. Similar periodic tasks can be implemented the same way. I also pushed up a version of this that uses Python threading instead of Celery, and I think that might be a better solution. We wouldn't need Celery or RabbitMQ/Redis (which are all very heavy dependencies), and aesthetically it's much nicer to have everything done through the CLI. As it is now, you must use:
`celery -A celery_target worker --beat`
to start the periodic tasks, which is uglier than `./freejournal_cli.py listen`.

Celery makes more sense if we're trying to serve files through the webapp that haven't been cached. If that's the case, a user's request can fire off a celery task to retrieve files from FreeNet which keeps things responsive for other users. I don't think we're doing that at this point (if we are, let me know), and instead we're only serving files that have been cached, in which case we can have two separate processes for the listener and the webapp.
