### PR TITLE
Changed CLI to use an argparse-based parser

### DIFF
--- a/frontend/cli/commands.py
+++ b/frontend/cli/commands.py
@@ -7,7 +7,7 @@ import config
 
 # Base parser
 parser = argparse.ArgumentParser(description="FreeJournal Client")
-subparsers = parser.add_subparsers(help="FreeJournal client commands", dest="command")
+subparsers = parser.add_subparsers(help="FreeJournal client commands", dest="command", metavar="<command>")
 
 # Subcommand parsers
 # getdoc
@@ -40,6 +40,7 @@ parser_listversions.add_argument("-d", "--documents", action="store_true", dest=
 # listen
 parser_listen = subparsers.add_parser("listen", help="start the long-running FreeJournal listener")
 
+# install
 parser_install = subparsers.add_parser("install", help="install FreeJournal dependencies")
 parser_install.add_argument("deps", choices=["freenet", "bitmessage", "all"], help="dependencies to install")
 

--- a/frontend/cli/commands.py
+++ b/frontend/cli/commands.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 
-import sys, datetime, uuid, argparse, platform
+import sys, datetime, uuid, argparse, platform, types
 
 from helpers import get_doc_file, put_document, list_collections, list_collection_version, list_collection_details, show_collection, install_dependencies, put_collection, publish_collection
 import config
@@ -14,14 +14,16 @@ class HelpfulParser(argparse.ArgumentParser):
 
 # Base parser
 parser = HelpfulParser(description="FreeJournal Client")
-subparsers = parser.add_subparsers(help="FreeJournal client commands", dest="command", metavar="<command>")
+subparsers = parser.add_subparsers(help="FreeJournal client command", dest="command", metavar="<command>")
 
 # Subcommand parsers
 # getdoc
 parser_getdoc = subparsers.add_parser("getdoc",
-                                      help="get a document with given hash from the FreeJournal network storage")
+                                      help="get a document with given hash\n \n from the FreeJournal\n network storage")
 parser_getdoc.add_argument("hash", type=str, help="hash of the document to get")
 parser_getdoc.add_argument("output_path", type=str, help="path to save the document to")
+parser_getdoc.parents = [parser_getdoc]
+subparsers._choices_actions[0].metavar = "getdoc [-h] hash output_path"
 
 # putdoc
 parser_putdoc = subparsers.add_parser("putdoc",
@@ -33,16 +35,19 @@ parser_putdoc.add_argument("path", type=str, help="path of the document to uploa
 parser_putdoc.add_argument("address", type=str, help="BitMessage address of the collection to add this document to")
 parser_putdoc.add_argument("title", type=str, help="title of the document")
 parser_putdoc.add_argument("description", type=str, help="description of the document")
+subparsers._choices_actions[1].metavar = "putdoc [-h] path address title description"
 
 # listcollections
 parser_listcollections = subparsers.add_parser("listcollections",
                                                help="list all document indexes currently known to this FreeJournal"
-                                                    + "instance")
+                                                    + " instance")
 
+# listversions
 parser_listversions = subparsers.add_parser("listversions", help="list all the versions of a particular collection")
 parser_listversions.add_argument("address", help="BitMessage address of the collection")
 parser_listversions.add_argument("-d", "--documents", action="store_true", dest="show_documents",
                                  help="print document_ids")
+subparsers._choices_actions[3].metavar = "listversions [-h] [-d] address"
 
 # listen
 parser_listen = subparsers.add_parser("listen", help="start the long-running FreeJournal listener")
@@ -50,11 +55,13 @@ parser_listen = subparsers.add_parser("listen", help="start the long-running Fre
 # install
 parser_install = subparsers.add_parser("install", help="install FreeJournal dependencies")
 parser_install.add_argument("deps", choices=["freenet", "bitmessage", "all"], help="dependencies to install")
+subparsers._choices_actions[5].metavar = "install [-h] deps"
 
 # showcollection
 parser_showcollection = subparsers.add_parser("showcollection", help="display all known details of a given collection,"
-                                                                     + "including all documents it indexes")
+                                                                     + " including all documents it indexes")
 parser_showcollection.add_argument("address", help="BitMessage address of the collection")
+subparsers._choices_actions[6].metavar = "showcollection [-h] address"
 
 # putcollection
 parser_putcollection = subparsers.add_parser("putcollection", help="create a new collection and store it locally")
@@ -63,12 +70,14 @@ parser_putcollection.add_argument("title", help="title for the new collection")
 parser_putcollection.add_argument("description", help="description for the new collection")
 parser_putcollection.add_argument("keywords", help="comma-separated keywords")
 parser_putcollection.add_argument("btc_address", help="Bitcoin address for donations")
+subparsers._choices_actions[7].metavar = "putcollection [-h] address_password title description keywords btc_address"
 
 # publishcollection
 parser_publishcollection = subparsers.add_parser("publishcollection", help="publish a local collection to the world"
                                                                            + "(other FreeJournal nodes)")
 parser_publishcollection.add_argument("address_password", help="the password for this collection")
 parser_publishcollection.add_argument("id", help="the BitMessage ID for this collection")
+subparsers._choices_actions[8].metavar = "publishcollection [-h] address_password id"
 
 # webapp
 parser_webapp = subparsers.add_parser("webapp", help="run the HTTP server front end")
@@ -78,7 +87,7 @@ parser_uploader = subparsers.add_parser("uploader", help="run the uploader GUI a
 
 # keepalive
 parser_keepalive = subparsers.add_parser("keepalive", help="run the keep-alive function to help sustain the FreeJournal"
-                                                           + "network")
+                                                           + " network")
 
 
 def process_command():

--- a/frontend/cli/commands.py
+++ b/frontend/cli/commands.py
@@ -5,8 +5,15 @@ import sys, datetime, uuid, argparse, platform
 from helpers import get_doc_file, put_document, list_collections, list_collection_version, list_collection_details, show_collection, install_dependencies, put_collection, publish_collection
 import config
 
+
+class HelpfulParser(argparse.ArgumentParser):
+    def error(self, message):
+        sys.stderr.write('error: %s\n' % message)
+        self.print_help()
+        exit(2)
+
 # Base parser
-parser = argparse.ArgumentParser(description="FreeJournal Client")
+parser = HelpfulParser(description="FreeJournal Client")
 subparsers = parser.add_subparsers(help="FreeJournal client commands", dest="command", metavar="<command>")
 
 # Subcommand parsers


### PR DESCRIPTION
From previous pull request that got reverted:

> The "commands" file was pretty messy, so I put together an `argparse` parser for command line arguments. It'll handle improper number of arguments/optional arguments/help text for us. There is only one breaking change I noticed which is that `listversions` now takes a `-d` or `--documents` flag for showing document versions, so instead of `./freejournal_cli.py listversions documents`, it's `./freejournal_cli.py listversions -d` or `./freejournal_cli.py listversions --documents`.

@pdaian, can you take a look at the help messages for the commands and make sure they look reasonable? Additionally, if naming is off for anything just let me know.
